### PR TITLE
Fixes syntax error, unexpected identifier "version"

### DIFF
--- a/resources/views/sitemap.blade.php
+++ b/resources/views/sitemap.blade.php
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?php echo '<?xml version="1.0" encoding="UTF-8"?>'; ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
 
     @foreach ($tags as $tag)


### PR DESCRIPTION
Fixes getting sintax error on sitemap rendering:

`syntax error, unexpected identifier "version" (View: ...../vendor/the-3labs-team/laravel-googlenews-sitemap/resources/views/sitemap.blade.php)`

This is due to `short_open_tag` still working on XML even if using PHP > 8